### PR TITLE
Fix: Edge for ios and android returns Mobile safari as the browser name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ IceCat, IceDragon, Iceweasel, IE[Mobile], Iron, Jasmine, K-Meleon, Konqueror, Ki
 Links, Lunascape, Lynx, Maemo, Maxthon, Midori, Minimo, MIUI Browser, [Mobile] Safari, 
 Mosaic, Mozilla, Netfront, Netscape, NetSurf, Nokia, OmniWeb, Opera [Mini/Mobi/Tablet], 
 PhantomJS, Phoenix, Polaris, QQBrowser, Quark, RockMelt, Silk, Skyfire, SeaMonkey, Sleipnir, 
-SlimBrowser, Swiftfox, Tizen, UCBrowser, Vivaldi, w3m, WeChat, Yandex
+SlimBrowser, Swiftfox, Tizen, UCBrowser, Vivaldi, w3m, Waterfox, WeChat, Yandex
 
 # 'browser.version' determined dynamically
 ```

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -261,7 +261,7 @@
             /(trident).+rv[:\s]([\w\.]+).+like\sgecko/i                         // IE11
             ], [[NAME, 'IE'], VERSION], [
 
-            /(edge|edgeios|edgea)\/((\d+)?[\w\.]+)/i                            // Microsoft Edge
+            /(edge|edgios|edgea)\/((\d+)?[\w\.]+)/i                            // Microsoft Edge
             ], [NAME, VERSION], [
 
             /(yabrowser)\/([\w\.]+)/i                                           // Yandex

--- a/src/ua-parser.js
+++ b/src/ua-parser.js
@@ -261,7 +261,7 @@
             /(trident).+rv[:\s]([\w\.]+).+like\sgecko/i                         // IE11
             ], [[NAME, 'IE'], VERSION], [
 
-            /(edge)\/((\d+)?[\w\.]+)/i                                          // Microsoft Edge
+            /(edge|edgeios|edgea)\/((\d+)?[\w\.]+)/i                            // Microsoft Edge
             ], [NAME, VERSION], [
 
             /(yabrowser)\/([\w\.]+)/i                                           // Yandex


### PR DESCRIPTION
Issue: browser.name returns `Mobile Safari` for edge browsers on mobiles. This will fix that bug.

More info: 
on mobile browsers, `navigator.appVersion` will have `EdgA` for android and `EdgiOS` for ios. 
I have also attached the screenshots for reference
1. for iPhone: 
![img_2421](https://user-images.githubusercontent.com/1021966/38200264-4698769c-36b1-11e8-93df-e3e150c9fc56.jpg)

2. for Android
![1858591746910083898](https://user-images.githubusercontent.com/1021966/38200268-4d3f1bcc-36b1-11e8-88e0-57a0d272e9a4.jpg)

